### PR TITLE
say_aboutをアクション化

### DIFF
--- a/game/scripts/f1/r1/screen.rpy
+++ b/game/scripts/f1/r1/screen.rpy
@@ -10,8 +10,8 @@ screen f1r1_screen(current):
                     ypos 0.8
                     yoffset 15
                     draggable False
-                    droppable False   
-                    clicked Call("say_about",calllabel="f1r1_door_clicked",jumplabel="f1r2_start")      
+                    droppable False
+                    clicked FromSc("f1r1_door_clicked", "f1r2_start")
 
             else:
                 drag:

--- a/game/scripts/title/screen.rpy
+++ b/game/scripts/title/screen.rpy
@@ -12,7 +12,7 @@ screen title_screen(current):
                     yanchor 0.5
                     draggable False
                     droppable False
-                    clicked Call("say_about", calllabel="title_start_clicked",jumplabel="menu_start")
+                    clicked FromSc("title_start_clicked", "menu_start")
 
 # スタートボタンがクリックされたときの処理
 label title_start_clicked:

--- a/game/zz_late_eval/classes/action.rpy
+++ b/game/zz_late_eval/classes/action.rpy
@@ -4,9 +4,9 @@ init python:
     # screenからセリフを呼び出したいときは必ずこれを使う
     class FromSc(Action):
 
-        def __init__(self, calllabel, jumplabel=None, **kwargs):
-            self.clabel = calllabel
-            self.jlabel = jumplabel
+        def __init__(self, calllabel_0, jumplabel_0=None, **kwargs):
+            self.clabel = calllabel_0
+            self.jlabel = jumplabel_0
             self.kwargs = kwargs
         
         def __call__(self):

--- a/game/zz_late_eval/classes/action.rpy
+++ b/game/zz_late_eval/classes/action.rpy
@@ -1,0 +1,13 @@
+init python:
+    # インタラクション的なことをしながらラベルを呼ぶ
+    # callするラベルは必ずreturnされなければならない
+    # screenからセリフを呼び出したいときは必ずこれを使う
+    class FromSc(Action):
+
+        def __init__(self, calllabel, jumplabel=None, **kwargs):
+            self.clabel = calllabel
+            self.jlabel = jumplabel
+            self.kwargs = kwargs
+        
+        def __call__(self):
+            renpy.call("say_about", calllabel_0=self.clabel, jumplabel_0=self.jlabel, **self.kwargs)

--- a/game/zz_late_eval/labels/labels01.rpy
+++ b/game/zz_late_eval/labels/labels01.rpy
@@ -10,17 +10,15 @@ label say_simple(msg, jumplabel=None):
     
     return
 
-# インタラクション的なことをしながらラベルを呼ぶ(要検証)
-# callするラベルは必ずreturnされなければならない
-# screenからセリフを呼び出したいときは必ずこれを使う
-label say_about(calllabel, jumplabel=None, **kwargs):
+# 直接呼ばない
+label say_about(calllabel_0, jumplabel_0=None, **kwargs):
     if not say_interact:
         $ say_interact = True
-        call expression calllabel pass (**kwargs) # must be returned
+        call expression calllabel_0 pass (**kwargs) # must be returned
         $ say_interact = False
-        if jumplabel != None:
+        if jumplabel_0 != None:
             python:
-                jl = jumplabel
+                jl = jumplabel_0
                 # calllabel,jumplabelなどの変数はドロップされる。
                 renpy.pop_call()
             jump expression jl


### PR DESCRIPTION
# 使い方
* `FromSc(calllabel, jumplabel, **kwargs)` `calllabel`をコールして、リターンしたら`jumplabel`に飛びます。`kwargs`で`calllabel`で呼ぶラベルの引数を指定できます。`calllabel`で呼ばれるラベルは必ずリターンしなければなりません