### PR TITLE
FromScとsay_aboutを廃止してEventとevent_endを追加

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -271,4 +271,4 @@ default current_room = 'default'
 default room_prefix = ""
 
 # 内部変数
-default say_interact = False
+default enable_event = True

--- a/game/scripts/event_global/obj_clicked.rpy
+++ b/game/scripts/event_global/obj_clicked.rpy
@@ -5,7 +5,7 @@ label obj_clicked(objname):
         call expression pref_lb
     elif renpy.has_label(lb):
         call expression lb
-    return
+    $ event_end(room_prefix + ".scloop")
 
 label table_clicked:
     show girl with dissolve

--- a/game/scripts/event_global/obj_screen.rpy
+++ b/game/scripts/event_global/obj_screen.rpy
@@ -1,4 +1,4 @@
-screen obj_screen(current, jlabeldict={}):
+screen obj_screen(current):
     layer "master"
     $ img_col = ["#FF0000", "#808000", "#00FF00", "#008080", "#0000FF", "#800080"]
     draggroup:
@@ -11,8 +11,5 @@ screen obj_screen(current, jlabeldict={}):
                     add SampleImage(item, 150, 150, img_col[i % 6])
                 draggable False
                 droppable False
-                if item in jlabeldict:
-                    clicked FromSc("obj_clicked", jlabeldict[item], objname=item)
-                else:
-                    clicked FromSc("obj_clicked", room_prefix + ".scloop", objname=item)
+                clicked Event("obj_clicked", objname=item)
                 properties default_obj_prop[item]

--- a/game/scripts/f1/r1/events/opening.rpy
+++ b/game/scripts/f1/r1/events/opening.rpy
@@ -37,4 +37,4 @@ label f1r1_ev_opening:
 
     hide girl with ldissolve
 
-    return
+    $ event_end("f1r1.scloop")

--- a/game/scripts/f1/r1/start.rpy
+++ b/game/scripts/f1/r1/start.rpy
@@ -12,7 +12,7 @@ label .scloop:
 
     if f1r1_evflg_opening:  # f1r1初回起動時
         $ f1r1_evflg_opening = False
-        call say_about("f1r1_ev_opening", "f1r1.scloop")
+        $ Event("f1r1_ev_opening")()
     
     if f1r1_jumplabel == "f1r2":
         $ f1r1_jumplabel = None

--- a/game/scripts/f1/r2/events/angry.rpy
+++ b/game/scripts/f1/r2/events/angry.rpy
@@ -43,4 +43,4 @@ label f1r2_ev_angry:
 
     hide robot1 angry with dissolve
 
-    return
+    $ event_end("f1r2.scloop")

--- a/game/scripts/f1/r2/events/opening.rpy
+++ b/game/scripts/f1/r2/events/opening.rpy
@@ -101,4 +101,4 @@ label f1r2_ev_opening:
 
     hide girl with dissolve
     
-    return
+    $ event_end("f1r2.scloop")

--- a/game/scripts/f1/r2/events/robot_clicked.rpy
+++ b/game/scripts/f1/r2/events/robot_clicked.rpy
@@ -29,4 +29,4 @@ label f1r2_ev_robot_clicked:
         hide robot1 onlayer screens with dissolve
 
     window hide
-    return
+    $ event_end("f1r2.scloop")

--- a/game/scripts/f1/r2/screen.rpy
+++ b/game/scripts/f1/r2/screen.rpy
@@ -1,22 +1,12 @@
 screen f1r2_screen(current, rob=True):
     layer "master"
-    $ img_col = ["#FF0000", "#808000", "#00FF00", "#008080", "#0000FF", "#800080"]
-    draggroup:
-        for i, item in enumerate(current):
-            drag:
-                drag_name item
-                if renpy.can_show(item.lower()):
-                    add item.lower()
-                else:
-                    add SampleImage(item, 150, 150, img_col[i % 6])
-                draggable False
-                droppable False
-                properties default_obj_prop[item]
-        if rob:
+    use obj_screen(current)
+    if rob:
+        draggroup:
             drag:
                 drag_name "Robot"
                 add SampleImage("Robot", 200, 500, "#000000", xcenter=0.5, ycenter=0.5)
                 draggable False
                 droppable False
-                clicked FromSc("f1r2_ev_robot_clicked", "f1r2.scloop")
+                clicked Event("f1r2_ev_robot_clicked")
 

--- a/game/scripts/f1/r2/start.rpy
+++ b/game/scripts/f1/r2/start.rpy
@@ -18,10 +18,10 @@ label .scloop:
 
         $ f1r2_evflg_opening = False
 
-        call say_about("f1r2_ev_opening", "f1r2.scloop")
+        $ Event("f1r2_ev_opening")()
 
     if f1r2_evflg_angry:
-        call say_about("f1r2_ev_angry", "f1r2.scloop")
+        $ Event("f1r2_ev_angry")()
     
     pause
 

--- a/game/scripts/menu/events/l1_clicked.rpy
+++ b/game/scripts/menu/events/l1_clicked.rpy
@@ -13,13 +13,9 @@ label menu2_ev_l1_clicked:
 
         hide girl
 
-        return
-    
     # f1へ2回目以降のジャンプ
-    if menu2_evflg_canjump_f1:
+    elif menu2_evflg_canjump_f1:
 
         $ menu2_jumplabel = "f1r1"
 
-        return
-
-    return
+    $ event_end("menu2.scloop")

--- a/game/scripts/menu/events/l2_clicked.rpy
+++ b/game/scripts/menu/events/l2_clicked.rpy
@@ -4,27 +4,24 @@ label menu2_ev_l2_clicked:
     # このラベルへの訪問が初めてで、f2にジャンプ可能な時
     if not jumped_menu2_ev_l2_clicked and menu2_evflg_canjump_f2:
         $ menu2_jumplabel = "f2r1"
-        
+
         show girl at right
 
         g "f2を初めて訪れるときのセリフ"
 
         hide girl
 
-        return
-    
     # f2へ2回目以降のジャンプ
-    if menu2_evflg_canjump_f2:
+    elif menu2_evflg_canjump_f2:
 
         $ menu2_jumplabel = "f2r1"
-        
-        return
-    
+
+
     # f2へジャンプできないとき->f1へ行くことを促す
     show girl smile at right
 
     g "まずはセーブデータ1に行ってみよう"
 
     hide girl
-    
-    return
+
+    $ event_end("menu2.scloop")

--- a/game/scripts/menu/events/l3_clicked.rpy
+++ b/game/scripts/menu/events/l3_clicked.rpy
@@ -11,17 +11,13 @@ label menu2_ev_l3_clicked:
 
         hide girl
 
-        return
-    
     # f3へ2回目以降のジャンプ
-    if menu2_evflg_canjump_f3:
+    elif menu2_evflg_canjump_f3:
 
         $ menu2_jumplabel = "f3r1"
-        
-        return
-    
+
     # f3どころかf2にすらジャンプできないとき
-    if not menu2_evflg_canjump_f2:
+    elif not menu2_evflg_canjump_f2:
         show girl smile at right
 
         g "まずはセーブデータ1に行ってみよう"
@@ -29,12 +25,11 @@ label menu2_ev_l3_clicked:
         hide girl
 
         return
-    
-    
+
     show girl smile at right
 
     g "次はセーブデータ2に行ってみよう"
 
     hide girl
-    
-    return
+
+    $ event_end("menu2.scloop")

--- a/game/scripts/menu/events/opening.rpy
+++ b/game/scripts/menu/events/opening.rpy
@@ -23,4 +23,4 @@ label menu2_ev_opening:
 
     hide girl
 
-    return
+    $ event_end("menu2.scloop")

--- a/game/scripts/menu/screen.rpy
+++ b/game/scripts/menu/screen.rpy
@@ -7,14 +7,14 @@ screen menu2_screen(enable):
         imagebutton:
             auto "256x192_%s.png"
             sensitive enable
-            action FromSc("menu2_ev_l1_clicked", "menu2.scloop") # ロードファイル1
+            action Event("menu2_ev_l1_clicked") # ロードファイル1
         imagebutton:
             auto "256x192_%s.png"
             sensitive enable
-            action FromSc("menu2_ev_l2_clicked", "menu2.scloop") # ロードファイル2
+            action Event("menu2_ev_l2_clicked") # ロードファイル2
         imagebutton:
             auto "256x192_%s.png"
             sensitive enable
-            action FromSc("menu2_ev_l3_clicked", "menu2.scloop") # ロードファイル3
+            action Event("menu2_ev_l3_clicked") # ロードファイル3
         for i in range(0, 5):
             add "256x192_idle"

--- a/game/scripts/menu/start.rpy
+++ b/game/scripts/menu/start.rpy
@@ -16,7 +16,7 @@ label .scloop:
 
     if menu2_evflg_opening:
         $ menu2_evflg_opening = False
-        call say_about(calllabel_0="menu2_ev_opening", jumplabel_0="menu2.scloop")
+        $ Event("menu2_ev_opening")()
     
     if menu2_jumplabel == "f1r1":
         $ menu2_jumpflg_f1 = None

--- a/game/scripts/title/events/opening.rpy
+++ b/game/scripts/title/events/opening.rpy
@@ -65,4 +65,4 @@ label title_ev_opening:
 
     hide girl
 
-    return
+    $ event_end()

--- a/game/scripts/title/events/start_clicked.rpy
+++ b/game/scripts/title/events/start_clicked.rpy
@@ -4,7 +4,7 @@
 
 label title_start_clicked:
     call title_ev_start_clicked
-    return
+    $ event_end("menu2")
 
 label title_ev_start_clicked:
     hide screen title_screen
@@ -15,4 +15,4 @@ label title_ev_start_clicked:
 
     hide girl
     
-    return 
+    return

--- a/game/scripts/title/screen.rpy
+++ b/game/scripts/title/screen.rpy
@@ -1,3 +1,3 @@
 screen title_screen(current):
     layer "master"
-    use obj_screen(current, {"Start": "menu2"})
+    use obj_screen(current)

--- a/game/scripts/title/start.rpy
+++ b/game/scripts/title/start.rpy
@@ -10,7 +10,7 @@ label .scloop:
 
     if title_evflg_opening:  # タイトル画面初回起動時
         $ title_evflg_opening = False  # タイトル画面初回起動時のフラグ無効化
-        call say_about("title_ev_opening", "title.scloop")
+        $ Event("title_ev_opening")()
 
     pause
 

--- a/game/zz_late_eval/classes/action.rpy
+++ b/game/zz_late_eval/classes/action.rpy
@@ -1,13 +1,32 @@
 init python:
-    # インタラクション的なことをしながらラベルを呼ぶ
-    # callするラベルは必ずreturnされなければならない
-    # screenからセリフを呼び出したいときは必ずこれを使う
-    class FromSc(Action):
 
-        def __init__(self, calllabel_0, jumplabel_0=None, **kwargs):
+    # Eventを終了させる関数
+    # jlabelはjump先のラベル
+    # jlabelを指定しない場合はreturnする場合と同じ場所に飛ぶ
+    def event_end(jlabel=None):
+        global enable_event
+        if enable_event:
+            renpy.error("there are no events to end")
+        else:
+            enable_event = True
+            if jlabel == None:
+                renpy.return_statement()
+            else:
+                renpy.pop_call()
+                renpy.jump(jlabel)
+    
+    # 他のインタラクションを禁止してラベルを呼ぶ
+    # Event終了後は必ずevent_end関数を呼ばなければならない
+    # screenからセリフを呼び出したいときは必ずこれを使う
+    class Event(Action):
+
+        def __init__(self, calllabel_0, **kwargs):
             self.clabel = calllabel_0
-            self.jlabel = jumplabel_0
             self.kwargs = kwargs
         
         def __call__(self):
-            renpy.call("say_about", calllabel_0=self.clabel, jumplabel_0=self.jlabel, **self.kwargs)
+            global enable_event
+            if enable_event:
+                enable_event = False
+                renpy.call(self.clabel, **self.kwargs)
+                enable_event = True

--- a/game/zz_late_eval/labels/labels01.rpy
+++ b/game/zz_late_eval/labels/labels01.rpy
@@ -10,20 +10,6 @@ label say_simple(msg, jumplabel=None):
     
     return
 
-# 直接呼ばない
-label say_about(calllabel_0, jumplabel_0=None, **kwargs):
-    if not say_interact:
-        $ say_interact = True
-        call expression calllabel_0 pass (**kwargs) # must be returned
-        $ say_interact = False
-        if jumplabel_0 != None:
-            python:
-                jl = jumplabel_0
-                # calllabel,jumplabelなどの変数はドロップされる。
-                renpy.pop_call()
-            jump expression jl
-    return
-
 # 引数を破棄してreturnする
 label nop(*args, **kwargs):
     return


### PR DESCRIPTION
# 実装した内容

* Eventの追加

## 追加した関数

* `event_end(jlabel)` イベントを終了して別のラベルに飛ぶ

## 追加したクラス

* `class Event(Action)` Eventを開始するアクション
* `Event(calllabel_0, **kwargs)` `calllabel_0`を引数`kwargs`で呼び、Eventを開始する

## 追加した変数・フラグ

* `default enable_event = True` Eventを新規に開始できるかを示すフラグ

## その他の変更

* 今までのスクリプトを新しい仕様に合わせて書き換えた

## デバッグしてほしいところ

* 今までと同じ動作をするか
* `Event`と`event_end`は使いやすいか
