### PR TITLE
ファイルを隠しファイルにするときにハッシュ値を変えないようにした

### DIFF
--- a/game/zz_late_eval/functions/function01.rpy
+++ b/game/zz_late_eval/functions/function01.rpy
@@ -84,9 +84,7 @@ init python :
                     result = subprocess.run(["attrib", "+H", objname], startupinfo=info)
                     return result.returncode == 0
                 elif renpy.macintosh:
-                    os.remove(objname)
-                    with open("." + objname, "wb") as f:
-                        f.write(hashlib.sha256(("." + objname).encode("utf-8")).digest())
+                    os.rename(objname, "." + objname)
                     return True
         return False
     
@@ -103,23 +101,24 @@ init python :
         path = os.path.join(user_dir_path, roomdir)
         if os.path.isdir(path):
             os.chdir(path)
-            if os.path.isfile(objname):
-                if renpy.windows:
+            if renpy.windows:
+                if os.path.isfile(objname):
                     info = subprocess.STARTUPINFO()
                     info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                     info.wShowWindow = subprocess.SW_HIDE
                     result = subprocess.run(["attrib", "-H", objname], startupinfo=info)
                     return result.returncode == 0
-                elif renpy.macintosh:
-                    os.remove(objname)
-                    with open(objname[1:], "wb") as f:
-                        f.write(hashlib.sha256(objname[1:].encode("utf-8")).digest())
+                    return True
+            elif renpy.macintosh:
+                if os.path.isfile("." + objname):
+                    os.rename("." + objname, objname)
                     return True
         return False
     
     # roomdirで指定したフォルダにobjnameのファイルが存在するとき、
     # そのファイルから隠しファイルの属性を取り除く
     # 成功: True, 失敗時False
+    # macの場合はobjnameは、'.'無しの名前で指定
     def give_nothidden(roomdir, objname):
         cwd = os.getcwd()
         cond = give_nothidden_raw(roomdir, objname)

--- a/game/zz_late_eval/functions/function03.rpy
+++ b/game/zz_late_eval/functions/function03.rpy
@@ -4,12 +4,12 @@ init python:
     # ファイルが隠しファイルかを判定
     # fpは絶対パスで指定
     def is_hidden_file(fp):
-        if renpy.windows:
+        if False:
             info = subprocess.STARTUPINFO()
             info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             info.wShowWindow = subprocess.SW_HIDE
             return subprocess.run(['attrib', fp], stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=info).stdout[4] == b'H'[0]
-        elif renpy.macintosh:
+        elif True:
             if os.path.isfile(fp):
                 return os.path.basename(fp)[:1] == '.'
             else:

--- a/game/zz_late_eval/functions/function03.rpy
+++ b/game/zz_late_eval/functions/function03.rpy
@@ -4,12 +4,12 @@ init python:
     # ファイルが隠しファイルかを判定
     # fpは絶対パスで指定
     def is_hidden_file(fp):
-        if False:
+        if renpy.windows:
             info = subprocess.STARTUPINFO()
             info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             info.wShowWindow = subprocess.SW_HIDE
             return subprocess.run(['attrib', fp], stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=info).stdout[4] == b'H'[0]
-        elif True:
+        elif renpy.macintosh:
             if os.path.isfile(fp):
                 return os.path.basename(fp)[:1] == '.'
             else:


### PR DESCRIPTION
# 実装した内容

* `give_hidden`と`give_nothidden`のmacosでの仕様変更

# 変更内容

* 指定したファイルのハッシュ値を変えないようにした
* `give_nothidden`関数で、オブジェクト名を`.`なしで指定するようにした

## デバッグしてほしいところ

* `give_hidden`と`give_nothidden`が動くか
