### PR TITLE
obj_clickedでobj_propが優先されない問題を修正

### DIFF
--- a/game/scripts/event_global/obj_clicked.rpy
+++ b/game/scripts/event_global/obj_clicked.rpy
@@ -1,7 +1,7 @@
-label obj_clicked(objname):
+label obj_clicked(objname, obj_prop={}):
     $ renpy.dynamic(lb=objname.lower().replace(" ", "_") + "_clicked")
     $ renpy.dynamic(pref_lb=room_prefix + "_" + lb)
-    $ renpy.show_screen("obj_screen", current=read_room())
+    $ renpy.show_screen("obj_screen", current=read_room(), obj_prop=obj_prop)
     if renpy.has_label(pref_lb):
         jump expression pref_lb
     elif renpy.has_label(lb):

--- a/game/scripts/event_global/obj_screen.rpy
+++ b/game/scripts/event_global/obj_screen.rpy
@@ -12,7 +12,7 @@ screen obj_screen(current, obj_prop={}):
                 draggable False
                 droppable False
                 if enable_event:
-                    clicked Event("obj_clicked", objname=item)
+                    clicked Event("obj_clicked", objname=item, obj_prop=obj_prop)
                 if item in obj_prop:
                     properties obj_prop[item]
                 else:


### PR DESCRIPTION
# 実装した内容

`obj_clicked`で`obj_prop`が引数として渡されず、クリック時の画面再描画で`default_obj_prop`が呼び出されてしまう問題を修正しました。

# 確認事項

`f1r2`で、`Door A`をクリックしたときに正しく画面表示が行われるか
その他問題が起こる箇所はないか