### PR TITLE
f1r1における描画バグについて

### DIFF
--- a/game/scripts/event_global/obj_clicked.rpy
+++ b/game/scripts/event_global/obj_clicked.rpy
@@ -1,7 +1,7 @@
 label obj_clicked(objname):
     $ renpy.dynamic(lb=objname.lower().replace(" ", "_") + "_clicked")
     $ renpy.dynamic(pref_lb=room_prefix + "_" + lb)
-    $ renpy.show_screen("obj_screen", current=read_room())
+    # $ renpy.show_screen("obj_screen", current=read_room())
     if renpy.has_label(pref_lb):
         jump expression pref_lb
     elif renpy.has_label(lb):

--- a/game/scripts/event_global/obj_clicked.rpy
+++ b/game/scripts/event_global/obj_clicked.rpy
@@ -1,7 +1,7 @@
 label obj_clicked(objname):
     $ renpy.dynamic(lb=objname.lower().replace(" ", "_") + "_clicked")
     $ renpy.dynamic(pref_lb=room_prefix + "_" + lb)
-    # $ renpy.show_screen("obj_screen", current=read_room())
+    $ renpy.show_screen(room_prefix + "_screen", current=read_room())
     if renpy.has_label(pref_lb):
         jump expression pref_lb
     elif renpy.has_label(lb):


### PR DESCRIPTION
# 初めに
f1r1で、よくわからんバグを見つけた。
一応対処法っぽいものを見つけたけど、釈然としないので確認してほしい。

# バグの再現方法

1. f1r1で、`Sofa`と`Table`がある状態で`Door A`をクリックし、「家具が邪魔だね」のイベントを呼び出す。
2. `Sofa`と`Table`をディレクトリから取り除き、画面を更新する。
3. 画面をクリックしても`Sofa`と`Table`が消えない。何かオブジェクトをクリックすると消える(謎ポイント1)
4. さらに`Sofa`と`Table`を復活させ、画面を更新すると、ドアが`Sofa`や`Table`より手前に表示されてしまう。オブジェクトをクリックすと治る(謎ポイント2)

# 考察

ドアをクリックしたことが原因っぽい。`obj_clicked`でスクリーンを呼びなおしているのが問題？
実際、その部分をコメントアウトすると治る(このブランチはその変更がされている)。

# どうする？

一応、先に示したコメントアウトによって、このような問題は(なぜか)起こらなくなる。
ところで、`obj_clicked`で`obj_screen`呼んでるのってなんで？もしこれが必須なら、このプルリクはダメな変更をしてるので、別の対策を考えないといけない。
これで問題がないならこのプルリクをapproveしてくれればOK