### PR TITLE
オブジェクトの描画順を指定できるように

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -227,45 +227,48 @@ define user_directory = "game_data"
 
 # オブジェクトのデフォルトのプロパティー
 # properties <辞書>でスタイルプロパティーを設定できる
+# indexは画面表示の優先順位を表す。indexが小さいオブジェクトから順に描画される。
+# index=0 => 壁と同じ階層, index=1 => 壁に接している家具,
+# index=2 => 壁の手前の家具, index=3 => Config等のボタン
 define default_obj_prop = {
     # prologue
-    "Key"            : {"anchor": (0.5, 0.5), "pos": (0.5, 0.8)},
+    "Key"            : {"index": 2, "anchor": (0.5, 0.5), "pos": (0.5, 0.8)},
 
     # title
-    "Start"          : {"anchor": (0.5, 0.5), "pos": (0.5, 0.5)},
-    "Config"         : {"anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
+    "Start"          : {"index": 3, "anchor": (0.5, 0.5), "pos": (0.5, 0.5)},
+    "Config"         : {"index": 3, "anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
 
     # menu
 
     # f1r1
-    "Books"          : {"anchor": (0.0, 0.0), "pos": ( 295,  936)},
-    "Bookshelf"      : {"anchor": (0.0, 0.0), "pos": (  94,  586)},
-    "Calendar"       : {"anchor": (0.0, 0.0), "pos": ( 163,   33)},
-    "Door A"         : {"anchor": (0.0, 0.0), "pos": (1045,  149)},
-    "Sofa"           : {"anchor": (0.0, 0.0), "pos": ( 692,  523)},
-    "Table"          : {"anchor": (0.0, 0.0), "pos": ( 875,  490)},
+    "Books"          : {"index": 2, "anchor": (0.0, 0.0), "pos": ( 295,  936)},
+    "Bookshelf"      : {"index": 1, "anchor": (0.0, 0.0), "pos": (  94,  586)},
+    "Calendar"       : {"index": 1, "anchor": (0.0, 0.0), "pos": ( 163,   33)},
+    "Door A"         : {"index": 0, "anchor": (0.0, 0.0), "pos": (1045,  149)},
+    "Sofa"           : {"index": 1, "anchor": (0.0, 0.0), "pos": ( 692,  523)},
+    "Table"          : {"index": 2, "anchor": (0.0, 0.0), "pos": ( 875,  490)},
 
     # f1r2
-    "Chest"          : {"anchor": (0.5, 0.0), "pos": (1113,  628)},
-    "Vase"           : {"anchor": (0.0, 0.0), "pos": (1124,  491)},
+    "Chest"          : {"index": 1, "anchor": (0.5, 0.0), "pos": (1113,  628)},
+    "Vase"           : {"index": 1, "anchor": (0.0, 0.0), "pos": (1124,  491)},
 
     # f1r3
-    "archive.tar.gz" : {"anchor": (0.5, 0.5), "pos": (0.6, 0.6)},
-    "Cupboard"       : {"anchor": (0.0, 0.0), "pos": (  35,   78)},
-    "document.docx"  : {"anchor": (0.5, 0.5), "pos": (0.7, 0.6)},
-    "document.zip"   : {"anchor": (0.5, 0.5), "pos": (0.8, 0.6)},
-    "Door B"         : {"anchor": (0.0, 0.0), "pos": (1539,  106)},
-    "fridge.7z"      : {"anchor": (0.5, 0.5), "pos": (0.3, 0.6)},
-    "fridge.zip"     : {"anchor": (0.5, 0.5), "pos": (0.2, 0.6)},
-    "fridge_pass.7z" : {"anchor": (0.5, 0.5), "pos": (0.4, 0.6)},
-    "fridge_pass.zip": {"anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
-    "Kitchen table"  : {"anchor": (0.0, 0.0), "pos": (  35,  518)},
-    "Box"            : {"anchor": (0.0, 0.0), "pos": (400, 340)},
-    "Box.png"        : {"anchor": (0.5, 0.5), "pos": (0.2, 0.1)},
-    "Mat"            : {"anchor": (0.0, 0.0), "pos": (  46,  855)},
+    "archive.tar.gz" : {"index": 1, "anchor": (0.5, 0.5), "pos": (0.6, 0.6)},
+    "Cupboard"       : {"index": 1, "anchor": (0.0, 0.0), "pos": (  35,   78)},
+    "document.docx"  : {"index": 2, "anchor": (0.5, 0.5), "pos": (0.7, 0.6)},
+    "document.zip"   : {"index": 2, "anchor": (0.5, 0.5), "pos": (0.8, 0.6)},
+    "Door B"         : {"index": 0, "anchor": (0.0, 0.0), "pos": (1539,  106)},
+    "fridge.7z"      : {"index": 1, "anchor": (0.5, 0.5), "pos": (0.3, 0.6)},
+    "fridge.zip"     : {"index": 1, "anchor": (0.5, 0.5), "pos": (0.2, 0.6)},
+    "fridge_pass.7z" : {"index": 1, "anchor": (0.5, 0.5), "pos": (0.4, 0.6)},
+    "fridge_pass.zip": {"index": 1, "anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
+    "Kitchen table"  : {"index": 1, "anchor": (0.0, 0.0), "pos": (  35,  518)},
+    "Box"            : {"index": 2, "anchor": (0.0, 0.0), "pos": (400, 340)},
+    "Box.png"        : {"index": 2, "anchor": (0.5, 0.5), "pos": (0.2, 0.1)},
+    "Mat"            : {"index": 2, "anchor": (0.0, 0.0), "pos": (  46,  855)},
 
     # f3r1
-    "Anywhere Door"  : {"anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
+    "Anywhere Door"  : {"index": 0, "anchor": (0.5, 0.5), "pos": (0.5, 0.6)},
 }
 
 # 読み込むファイルのlist

--- a/game/scripts/event_global/obj_screen.rpy
+++ b/game/scripts/event_global/obj_screen.rpy
@@ -11,7 +11,6 @@ screen obj_screen(current, obj_prop={}):
         ]
         # indexの値でソート
         prop = dict(sorted(prop, key=lambda x: x[1]["index"]))
-        print(prop)
     
     draggroup:
         for i, item in enumerate(prop.keys()):

--- a/game/scripts/event_global/obj_screen.rpy
+++ b/game/scripts/event_global/obj_screen.rpy
@@ -1,8 +1,20 @@
 screen obj_screen(current, obj_prop={}):
     layer "master"
     $ img_col = ["#FF0000", "#808000", "#00FF00", "#008080", "#0000FF", "#800080"]
+
+    python:
+        # obj_propとdefault_obj_propを統合し、indexの値で昇順にソート
+        # prop = [(オブジェクト名, そのプロパティ), ...]
+        prop = [
+            (item, obj_prop[item] if item in obj_prop else default_obj_prop[item])
+                    for item in current
+        ]
+        # indexの値でソート
+        prop = dict(sorted(prop, key=lambda x: x[1]["index"]))
+        print(prop)
+    
     draggroup:
-        for i, item in enumerate(current):
+        for i, item in enumerate(prop.keys()):
             drag:
                 drag_name item
                 if renpy.can_show(item.lower()):
@@ -13,10 +25,7 @@ screen obj_screen(current, obj_prop={}):
                 droppable False
                 if enable_event:
                     clicked Event("obj_clicked", objname=item)
-                if item in obj_prop:
-                    properties obj_prop[item]
-                else:
-                    properties default_obj_prop[item]
+                properties prop[item]
 
 screen obj_screen_pos_obj(current,x_pos,y_pos):
     layer "master"

--- a/game/scripts/f1/r2/screen.rpy
+++ b/game/scripts/f1/r2/screen.rpy
@@ -1,6 +1,6 @@
 # この部屋のプロパティ
 define f1r2_obj_prop = {
-    "Door A": {"anchor": (0.0, 0.0), "pos": (1404, 179)},
+    "Door A": {"index": 0, "anchor": (0.0, 0.0), "pos": (1404, 179)},
 }
 
 screen f1r2_screen(current, rob=True):


### PR DESCRIPTION
# 実装した内容

オブジェクトの描画順によって、いつか見た目が壊れるような気がしたので先に対処。
オブジェクトのプロパティに、`index`の項目を追加しました。
この値が小さいほど描画の優先順位が高くなります。

* 大まかな実装内容

`obj_screen`が割と変わってます。
`obj_prop`と`default_obj_prop`をいい感じに統合した後に、`index`でソートして順に描画します。

## 追加した変数

`obj_screen`で、中間の変数として`prop`が生成されます。
上記の通り、`obj_prop`と`default_obj_prop`をいい感じに統合したやつです

## デバッグしてほしいところ

`prop`の変数が意図通りか
動くか(特に`f1r2`)

## 既知のバグ
