### PR TITLE
ロボット君がコピー先に同名のファイルがあると壊れる問題を修正

### DIFF
--- a/game/scripts/f1/r2/events.rpy
+++ b/game/scripts/f1/r2/events.rpy
@@ -13,7 +13,7 @@ init python:
         os.chdir(room2path)
         path = "../room1"
         for o in objlist:
-            shutil.move(o, path)
+            shutil.move(o, os.path.join(path, o))
         os.chdir(cwd)
 
     # 隠しファイルでないファイルを取得


### PR DESCRIPTION
# 実装した内容

`robot_angry`のイベントにおいて、コピー先に同名のファイルがあるとエラーが出る問題を、
ファイルの上書きによって修正しました。

`shutil.move`は、第二引数にファイルパスを指定すると上書きになるようです。

## デバッグしてほしいところ

同名のファイルが移動先にある場合に上書きが行われるか
この実装で問題ないか。