### PR TITLE
f1r2: ロボットの可視・不可視を調整

### DIFF
--- a/game/scripts/f1/r2/events/angry.rpy
+++ b/game/scripts/f1/r2/events/angry.rpy
@@ -2,6 +2,8 @@
 default f1r2_jumped_ev_angry = False  # このラベルに訪問済みか
 
 label f1r2_ev_angry:
+    show screen f1r2_screen(read_room(), visible=False) with dissolve
+
     show robot1 angry at left with dissolve
 
     ro1 "この部屋に、"
@@ -11,8 +13,7 @@ label f1r2_ev_angry:
     ro1 "持ち込むなー！！！！"
 
     $ move_obj(nhidden)
-    show screen f1r2_screen(read_room())
-    with dissolve
+    show screen f1r2_screen(read_room(), visible=False) with dissolve
 
     # このラベルを初めて訪れた時
     if not f1r2_jumped_ev_angry:

--- a/game/scripts/f1/r2/events/clicked_hidden.rpy
+++ b/game/scripts/f1/r2/events/clicked_hidden.rpy
@@ -10,6 +10,8 @@ label f1r2_ev_hidden_clicked:
 
     hide girl with dissolve
 
+    show screen f1r2_screen(read_room(), visible=False) with dissolve
+
     show girl at right with dissolve
     show robot1 at left with dissolve
 

--- a/game/scripts/f1/r2/events/door_clickked.rpy
+++ b/game/scripts/f1/r2/events/door_clickked.rpy
@@ -11,8 +11,9 @@ label f1r2_door_a_clicked:
 
         g "ばれないようにドアを設置するなんて。まさに完全犯罪だ"
 
-        show girl at right with dissolve
+        show screen f1r2_screen(read_room(), visible=False) with dissolve
 
+        show girl at right with dissolve
         show robot1 at left with dissolve
         
         ro1 "何を隠れて話しているのだね、君たち"

--- a/game/scripts/f1/r2/events/opening.rpy
+++ b/game/scripts/f1/r2/events/opening.rpy
@@ -3,6 +3,9 @@ label f1r2_ev_opening:
 
     g "ずいぶん殺風景な部屋だね......真っ白"
 
+    show screen f1r2_screen(read_room(), visible=False) with dissolve
+    
+    show girl at right with dissolve
     show robot1 at left with dissolve
 
     ro1_unknown "......む、なんだね君たちは"
@@ -84,6 +87,10 @@ label f1r2_ev_opening:
     hide robot1 with dissolve
 
     hide girl with dissolve
+
+    show girl at center with dissolve
+
+    show screen f1r2_screen(read_room(), visible=True)
 
     show girl at center with dissolve
 

--- a/game/scripts/f1/r2/events/robot_clicked.rpy
+++ b/game/scripts/f1/r2/events/robot_clicked.rpy
@@ -2,7 +2,7 @@
 default f1r2_jumped_robot_clicked = False
 
 label f1r2_ev_robot_clicked:
-    show screen f1r2_screen(read_room(), False)  # ロボットを不可視に
+    show screen f1r2_screen(read_room(), visible=False)  # ロボットを不可視に
     show robot1 at left with dissolve
     show girl at right with dissolve
 
@@ -29,6 +29,8 @@ label f1r2_ev_robot_clicked:
 
         hide robot1
         hide girl with dissolve
+
+        show screen f1r2_screen(read_room(), visible=True)  # ロボットを不可視に
 
         show girl look away with dissolve
 

--- a/game/scripts/f1/r2/screen.rpy
+++ b/game/scripts/f1/r2/screen.rpy
@@ -3,7 +3,8 @@ define f1r2_obj_prop = {
     "Door A": {"index": 0, "anchor": (0.0, 0.0), "pos": (1404, 179)},
 }
 
-screen f1r2_screen(current, rob=True):
+# visible: Trueのときロボットを表示
+screen f1r2_screen(current, visible=True, rob=True):
     layer "master"
 
     drag:
@@ -19,26 +20,27 @@ screen f1r2_screen(current, rob=True):
 
     use obj_screen(current, f1r2_obj_prop)
 
-    if rob:
-        draggroup:
-            drag:
-                drag_name "Robot"
-                if renpy.can_show("robot"):
-                    add "robot"
-                else:
-                    add SampleImage("robot", 150, 150, "#FF0000")
-                draggable False
-                droppable False
-                clicked Event("f1r2_ev_robot_clicked")
-                pos (671, 601)
-    else:
-        draggroup:
-            drag:
-                drag_name "Robot Angry"
-                if renpy.can_show("robot angry"):
-                    add "robot angry"
-                else:
-                    add SampleImage("robot angry", 150, 150, "#FF0000")
-                draggable False
-                droppable False
-                pos (673, 597)
+    if visible:
+        if rob:
+            draggroup:
+                drag:
+                    drag_name "Robot"
+                    if renpy.can_show("robot"):
+                        add "robot"
+                    else:
+                        add SampleImage("robot", 150, 150, "#FF0000")
+                    draggable False
+                    droppable False
+                    clicked Event("f1r2_ev_robot_clicked")
+                    pos (671, 601)
+        else:
+            draggroup:
+                drag:
+                    drag_name "Robot Angry"
+                    if renpy.can_show("robot angry"):
+                        add "robot angry"
+                    else:
+                        add SampleImage("robot angry", 150, 150, "#FF0000")
+                    draggable False
+                    droppable False
+                    pos (673, 597)


### PR DESCRIPTION
# 実装した内容
会話中に、ロボットが二つ表示される問題を修正しました

## デバッグしてほしいところ

スクリーン系はあまり知識がないので怖さがあるので、なんかやらかしてそう
